### PR TITLE
Add more http field name constants

### DIFF
--- a/src/http_header_name.ts
+++ b/src/http_header_name.ts
@@ -1,6 +1,9 @@
 /**
  *  - We don't use TypeScript enum for constants defined in this module to make them tree-shaking friendly.
  *  - This module should only contain well known http header field name values.
+ *
+ *  @see
+ *      - https://www.iana.org/assignments/http-fields/http-fields.xhtml
  */
 
 /**


### PR DESCRIPTION
This adds field name defined by these specs:

- https://w3c.github.io/webappsec-fetch-metadata/
- https://www.rfc-editor.org/rfc/rfc9110.html#name-message-context
- https://w3c.github.io/server-timing/#the-server-timing-header-field
- https://www.rfc-editor.org/rfc/rfc9110.html#name-content-negotiation
- https://fetch.spec.whatwg.org/#origin-header
- https://w3c.github.io/resource-timing/#sec-timing-allow-origin
- https://www.rfc-editor.org/rfc/rfc9110.html#name-representation-data-and-met
- https://fetch.spec.whatwg.org/#http-cors-protocol
- https://html.spec.whatwg.org/multipage/origin.html#coep
- https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies
- https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header