### PR TITLE
Rename `MimeType` to `Mime`

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -3,4 +3,4 @@ export * as CSP from './csp/mod.js';
 export * as HttpHeaderName from './http_header_name.js';
 export * as HttpMethod from './http_method.js';
 export * as HttpStatus from './http_status_code.js';
-export * as MimeType from './mime.js';
+export * as Mime from './mime.js';


### PR DESCRIPTION
`MimeType` is defined in typescript's `lib.dom.d.ts`. So vscode's IntelliSense suggests it first instead of one provided by this package even if we add this package to the project dependency.

To improve suggestion, and to improve a bit redundant naming, we rename to `Mime`.