### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+updates:
+    - package-ecosystem: github-actions
+      directory: '/'
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 99
+      labels:
+          - 'A-dependency/gardening'
+          - I-enhancement
+
+    - package-ecosystem: npm
+      directory: '/'
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 99
+      labels:
+          - 'A-dependency/gardening'
+          - I-enhancement


### PR DESCRIPTION
This repository's dependencies are small relatively and we don't intend to grow it rapidly in near term.
I think dependabot is nice for this scale rather than [renovate](https://github.com/renovatebot/renovate).

Fix #6