### PR TITLE
Run cleanup scripts concurrently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             ],
             "devDependencies": {
                 "prettier": "^2.7.1",
-                "typescript": "^4.7.4"
+                "typescript": "^4.7.4",
+                "zx": "^7.0.8"
             }
         },
         "node_modules/@nikkei/http-helper": {
@@ -49,6 +50,39 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@types/fs-extra": {
+            "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/minimist": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+            "dev": true
+        },
+        "node_modules/@types/node": {
+            "version": "18.6.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
+            "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
+            "dev": true
+        },
+        "node_modules/@types/ps-tree": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.2.tgz",
+            "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw==",
+            "dev": true
+        },
+        "node_modules/@types/which": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+            "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+            "dev": true
         },
         "node_modules/acorn": {
             "version": "8.8.0",
@@ -464,6 +498,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/date-time": {
             "version": "3.1.0",
             "license": "MIT",
@@ -579,6 +622,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "dev": true
+        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "license": "MIT"
@@ -632,6 +681,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+            "dev": true,
+            "dependencies": {
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
+            }
+        },
         "node_modules/fast-diff": {
             "version": "1.2.0",
             "license": "Apache-2.0"
@@ -655,6 +719,29 @@
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
             }
         },
         "node_modules/figures": {
@@ -693,6 +780,38 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dev": true,
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
+        "node_modules/from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+            "dev": true
+        },
+        "node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/fs.realpath": {
@@ -909,6 +1028,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
         "node_modules/js-string-escape": {
             "version": "1.0.1",
             "license": "MIT",
@@ -925,6 +1050,18 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/load-json-file": {
@@ -973,6 +1110,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
+            "dev": true
         },
         "node_modules/matcher": {
             "version": "5.0.0",
@@ -1049,9 +1192,52 @@
                 "node": "*"
             }
         },
+        "node_modules/minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "license": "MIT"
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+            "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+            "dev": true,
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
         },
         "node_modules/nofilter": {
             "version": "3.1.0",
@@ -1175,6 +1361,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+            "dev": true,
+            "dependencies": {
+                "through": "~2.3"
+            }
+        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "license": "MIT",
@@ -1238,6 +1433,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ps-tree": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+            "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+            "dev": true,
+            "dependencies": {
+                "event-stream": "=3.3.4"
+            },
+            "bin": {
+                "ps-tree": "bin/ps-tree.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/queue-microtask": {
@@ -1385,6 +1595,18 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
+        "node_modules/split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+            "dev": true,
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "license": "BSD-3-Clause"
@@ -1404,6 +1626,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+            "dev": true,
+            "dependencies": {
+                "duplexer": "~0.1.1"
             }
         },
         "node_modules/string-width": {
@@ -1454,6 +1685,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true
+        },
         "node_modules/time-zone": {
             "version": "1.0.0",
             "license": "MIT",
@@ -1494,11 +1731,44 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/well-known-symbols": {
             "version": "2.0.0",
             "license": "ISC",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/wrap-ansi": {
@@ -1595,6 +1865,15 @@
             "version": "4.0.0",
             "license": "ISC"
         },
+        "node_modules/yaml": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+            "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/yargs": {
             "version": "17.5.1",
             "license": "MIT",
@@ -1668,6 +1947,33 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/zx": {
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.8.tgz",
+            "integrity": "sha512-sNjfDHzskqrSkWNj0TVhaowVK5AbpvuyuO1RBU4+LrFcgYI5u9CtyWWgUBRtRZl3bgGEF31zByszoBmwS47d1w==",
+            "dev": true,
+            "dependencies": {
+                "@types/fs-extra": "^9.0.13",
+                "@types/minimist": "^1.2.2",
+                "@types/node": "^18.6.3",
+                "@types/ps-tree": "^1.1.2",
+                "@types/which": "^2.0.1",
+                "chalk": "^5.0.1",
+                "fs-extra": "^10.1.0",
+                "globby": "^13.1.2",
+                "minimist": "^1.2.6",
+                "node-fetch": "3.2.8",
+                "ps-tree": "^1.2.0",
+                "which": "^2.0.2",
+                "yaml": "^2.1.1"
+            },
+            "bin": {
+                "zx": "build/cli.js"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
+            }
+        },
         "packages/http-helper": {
             "name": "@nikkei/http-helper",
             "version": "0.7.1",
@@ -1717,6 +2023,39 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
+        },
+        "@types/fs-extra": {
+            "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/minimist": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "18.6.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
+            "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
+            "dev": true
+        },
+        "@types/ps-tree": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.2.tgz",
+            "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw==",
+            "dev": true
+        },
+        "@types/which": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+            "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+            "dev": true
         },
         "acorn": {
             "version": "8.8.0"
@@ -1960,6 +2299,12 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+            "dev": true
+        },
         "date-time": {
             "version": "3.1.0",
             "requires": {
@@ -2028,6 +2373,12 @@
                 "path-type": "^4.0.0"
             }
         },
+        "duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "dev": true
+        },
         "eastasianwidth": {
             "version": "0.2.0"
         },
@@ -2049,6 +2400,21 @@
         "esutils": {
             "version": "2.0.3"
         },
+        "event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+            "dev": true,
+            "requires": {
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
+            }
+        },
         "fast-diff": {
             "version": "1.2.0"
         },
@@ -2066,6 +2432,16 @@
             "version": "1.13.0",
             "requires": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "dev": true,
+            "requires": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
             }
         },
         "figures": {
@@ -2086,6 +2462,32 @@
             "requires": {
                 "locate-path": "^7.1.0",
                 "path-exists": "^5.0.0"
+            }
+        },
+        "formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dev": true,
+            "requires": {
+                "fetch-blob": "^3.1.2"
+            }
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             }
         },
         "fs.realpath": {
@@ -2197,6 +2599,12 @@
         "is-unicode-supported": {
             "version": "1.2.0"
         },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
         "js-string-escape": {
             "version": "1.0.1"
         },
@@ -2205,6 +2613,16 @@
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
+            }
+        },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
             }
         },
         "load-json-file": {
@@ -2230,6 +2648,12 @@
             "requires": {
                 "p-defer": "^1.0.0"
             }
+        },
+        "map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
+            "dev": true
         },
         "matcher": {
             "version": "5.0.0",
@@ -2269,8 +2693,31 @@
                 "brace-expansion": "^1.1.7"
             }
         },
+        "minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
         "ms": {
             "version": "2.1.3"
+        },
+        "node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "dev": true
+        },
+        "node-fetch": {
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+            "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+            "dev": true,
+            "requires": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            }
         },
         "nofilter": {
             "version": "3.1.0"
@@ -2329,6 +2776,15 @@
         "path-type": {
             "version": "4.0.0"
         },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+            "dev": true,
+            "requires": {
+                "through": "~2.3"
+            }
+        },
         "picomatch": {
             "version": "2.3.1"
         },
@@ -2355,6 +2811,15 @@
             "version": "7.0.1",
             "requires": {
                 "parse-ms": "^2.1.0"
+            }
+        },
+        "ps-tree": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+            "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+            "dev": true,
+            "requires": {
+                "event-stream": "=3.3.4"
             }
         },
         "queue-microtask": {
@@ -2418,6 +2883,15 @@
                 "is-fullwidth-code-point": "^4.0.0"
             }
         },
+        "split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+            "dev": true,
+            "requires": {
+                "through": "2"
+            }
+        },
         "sprintf-js": {
             "version": "1.0.3"
         },
@@ -2430,6 +2904,15 @@
                 "escape-string-regexp": {
                     "version": "2.0.0"
                 }
+            }
+        },
+        "stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+            "dev": true,
+            "requires": {
+                "duplexer": "~0.1.1"
             }
         },
         "string-width": {
@@ -2458,6 +2941,12 @@
         "temp-dir": {
             "version": "2.0.0"
         },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true
+        },
         "time-zone": {
             "version": "1.0.0"
         },
@@ -2476,8 +2965,29 @@
             "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
             "dev": true
         },
+        "universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true
+        },
+        "web-streams-polyfill": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+            "dev": true
+        },
         "well-known-symbols": {
             "version": "2.0.0"
+        },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
         },
         "wrap-ansi": {
             "version": "7.0.0",
@@ -2534,6 +3044,12 @@
         "yallist": {
             "version": "4.0.0"
         },
+        "yaml": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+            "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+            "dev": true
+        },
         "yargs": {
             "version": "17.5.1",
             "requires": {
@@ -2576,6 +3092,27 @@
         },
         "yocto-queue": {
             "version": "1.0.0"
+        },
+        "zx": {
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.8.tgz",
+            "integrity": "sha512-sNjfDHzskqrSkWNj0TVhaowVK5AbpvuyuO1RBU4+LrFcgYI5u9CtyWWgUBRtRZl3bgGEF31zByszoBmwS47d1w==",
+            "dev": true,
+            "requires": {
+                "@types/fs-extra": "^9.0.13",
+                "@types/minimist": "^1.2.2",
+                "@types/node": "^18.6.3",
+                "@types/ps-tree": "^1.1.2",
+                "@types/which": "^2.0.1",
+                "chalk": "^5.0.1",
+                "fs-extra": "^10.1.0",
+                "globby": "^13.1.2",
+                "minimist": "^1.2.6",
+                "node-fetch": "3.2.8",
+                "ps-tree": "^1.2.0",
+                "which": "^2.0.2",
+                "yaml": "^2.1.1"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     },
     "devDependencies": {
         "prettier": "^2.7.1",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "zx": "^7.0.8"
     }
 }

--- a/packages/http-helper/package.json
+++ b/packages/http-helper/package.json
@@ -24,9 +24,7 @@
         }
     },
     "scripts": {
-        "clean": "npm run clean:dist && npm run clean:tsbuildinfo",
-        "clean:dist": "rm -rf __dist/",
-        "clean:tsbuildinfo": "rm -rf tsconfig.tsbuildinfo",
+        "clean": "zx ./tools/clean.js",
         "prebuild": "npm run clean",
         "build": "tsc --project ."
     },

--- a/packages/http-helper/tools/clean.js
+++ b/packages/http-helper/tools/clean.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+
+const CWD = process.cwd();
+
+await Promise.all([
+    // @prettier-ignore
+    $`rm -rf ${CWD}/__dist/`,
+    $`rm -rf ${CWD}/tsconfig.tsbuildinfo`,
+]);


### PR DESCRIPTION
This pr introduce [zx](https://github.com/google/zx).

[concurrently](https://www.npmjs.com/package/concurrently) was also candidate, but we'd like to write a script flexibly and adopt zx in this commit.

## Alternative Approach

1. Write cleanup codes fully with Node.js `fs`.
    - This will achieve dependency-free for zx. However, I'd like to do simple migration.
    - Of course, we may rewrite this script with Node.js `fs` in the future. This is just _not now_.