### PR TITLE
Use Node.js v18.7.0 to fix the test has failed on Node 18.8.0

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -6,7 +6,7 @@ runs:
     steps:
         - uses: actions/setup-node@v3
           with:
-              node-version: 18
+              node-version: 18.7.0
               cache: 'npm'
         - name: Install dependencies
           shell: bash


### PR DESCRIPTION
Fix #69 

Since [Node v18.8.0 released today](https://nodejs.org/en/blog/release/v18.8.0/), our unittest has been failed.