### PR TITLE
Update ava to fix test errors with Node 18.8

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -6,7 +6,7 @@ runs:
     steps:
         - uses: actions/setup-node@v3
           with:
-              node-version: 18.7.0
+              node-version: 18
               cache: 'npm'
         - name: Install dependencies
           shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,8 +151,9 @@
             }
         },
         "node_modules/ava": {
-            "version": "4.3.1",
-            "license": "MIT",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
+            "integrity": "sha512-9Egq/d9R74ExrWohHeqUlexjDbgZJX5jA1Wq4KCTqc3wIfpGEK79zVy4rBtofJ9YKIxs4PzhJ8BgbW5PlAYe6w==",
             "dependencies": {
                 "acorn": "^8.7.1",
                 "acorn-walk": "^8.2.0",
@@ -1682,7 +1683,7 @@
             "version": "0.0.0",
             "dependencies": {
                 "@nikkei/http-helper": "*",
-                "ava": "^4.3.1",
+                "ava": "^4.3.3",
                 "option-t": "^32.6.0"
             }
         }
@@ -1698,7 +1699,7 @@
             "version": "file:packages/unittests",
             "requires": {
                 "@nikkei/http-helper": "*",
-                "ava": "^4.3.1",
+                "ava": "^4.3.3",
                 "option-t": "^32.6.0"
             }
         },
@@ -1764,7 +1765,9 @@
             "version": "3.0.0"
         },
         "ava": {
-            "version": "4.3.1",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
+            "integrity": "sha512-9Egq/d9R74ExrWohHeqUlexjDbgZJX5jA1Wq4KCTqc3wIfpGEK79zVy4rBtofJ9YKIxs4PzhJ8BgbW5PlAYe6w==",
             "requires": {
                 "acorn": "^8.7.1",
                 "acorn-walk": "^8.2.0",

--- a/packages/unittests/package.json
+++ b/packages/unittests/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@nikkei/http-helper": "*",
-        "ava": "^4.3.1",
+        "ava": "^4.3.3",
         "option-t": "^32.6.0"
     }
 }


### PR DESCRIPTION
https://github.com/avajs/ava/releases/tag/v4.3.3

This fix this workaround https://github.com/Nikkei/node-http-helper/pull/70