### PR TITLE
Publish the package publicly in our automation.

### DIFF
--- a/.github/workflows/publish_package_to_npm.yaml
+++ b/.github/workflows/publish_package_to_npm.yaml
@@ -19,7 +19,7 @@ jobs:
             - uses: ./.github/actions/prepare_ci
             - run: npm run build
               shell: bash
-            - run: npm publish --workspace=packages/http-helper --access=restricted
+            - run: npm publish --workspace=packages/http-helper --access=public
               shell: bash
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fix #88

This package is public now. We should use `npm publish --access=public`
https://docs.npmjs.com/cli/v9/commands/npm-access#details

After we merge this, I'll try to publish new patch version.