### PR TITLE
Re-number to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1700,7 +1700,7 @@
         },
         "packages/http-helper": {
             "name": "@nikkei/http-helper",
-            "version": "0.10.4",
+            "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
                 "option-t": "^33.8.0"

--- a/packages/http-helper/package.json
+++ b/packages/http-helper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nikkei/http-helper",
-    "version": "0.10.4",
+    "version": "1.0.0",
     "type": "module",
     "files": [
         "__dist/",


### PR DESCRIPTION
Under v0.x, we have only these options either "breaking changes including a new feature", or "bug fix" even if we don't have any breaking changes. This is a bit inconvenient from the perspective of release engineering.

Now, we're stable relatively. We would like to shift to v1.0 to get a new option "add a new feature but not contain any breaking changes".

Of course, we might face to requirement to break exist APIs. Then we should be up major version confidently.

And I think the breaking change of this is less problematic for our user because:

1. We supports tree shaking completely. Even if a user project's dependency
   graph contains multiple versions of us, then module bundler would
   handle it nice and eliminate unused "dead" code.
2. Our motto is that providing a set which are small but redundant to re-implement.
   I believe that an user project often easy to reimplement them in
   their project source tree.