### PR TITLE
Stop dependabot for TypeScript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,12 @@ updates:
       labels:
           - 'A-dependency/gardening'
           - I-enhancement
+      ignore:
+          # When we upgrade TypeScript, the emitted d.ts code may contain some breaking changes.
+          # This mean that we should release its change as major update strictly.
+          # Our (current) design allows that an user project contains multiple version of this
+          # So we cap to update typescript by dependabot.
+          # This does not mean to restrict us. We can update typescript when we want!
+          # This make to stop the automatic flow for it.
+          - dependency-name: typescript
+            update-types: ['version-update:semver-major', 'version-update:semver-minor']


### PR DESCRIPTION
When we upgrade TypeScript, the emitted d.ts code may contain some breaking changes. This mean that we should release its change as major update strictly. Our (current) design allows that an user project contains multiple version of this So we cap to update typescript by dependabot.

**This does not mean to restrict us. We can update typescript when we want! This make to stop the automatic flow for it.**

Alternative consideration
-------------------------

I also thought to introduce https://github.com/sandersn/downlevel-dts. But it requires to change our build system that depends on TS' project reference currently.

I think we don't have a strong motivation to do it to keep to use the latest TypeScript version for this project.