### PR TITLE
Enable dependabot's grouped update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,8 @@ updates:
           # This make to stop the automatic flow for it.
           - dependency-name: typescript
             update-types: ['version-update:semver-major', 'version-update:semver-minor']
+      # - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      groups:
+          typescript-eslint:
+              patterns:
+                  - '@typescript-eslint/*'


### PR DESCRIPTION
See:
- https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups