### PR TITLE
Implement `TRACEPARENT` & `TRACESTATE` http headers

### DIFF
--- a/packages/http-helper/src/http_header_name.ts
+++ b/packages/http-helper/src/http_header_name.ts
@@ -467,6 +467,18 @@ export const TE = 'te';
 export const TIMING_ALLOW_ORIGIN = 'timing-allow-origin';
 
 /**
+ *  - https://w3c.github.io/trace-context/#traceparent-header
+ *      - https://www.w3.org/TR/trace-context-2/#traceparent-header
+ */
+export const TRACEPARENT = 'traceparent';
+
+/**
+ *  - https://www.w3.org/TR/trace-context-2/#tracestate-header
+ *      - https://w3c.github.io/trace-context/#tracestate-header
+ */
+export const TRACESTATE = 'tracestate';
+
+/**
  *  - https://www.rfc-editor.org/rfc/rfc9110.html#name-trailer
  *  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
  */


### PR DESCRIPTION
These are defined by:

- https://w3c.github.io/trace-context/#traceparent-header
    - https://www.w3.org/TR/trace-context-2/#traceparent-header
- https://www.w3.org/TR/trace-context-2/#tracestate-header
    - https://w3c.github.io/trace-context/#tracestate-header