### PR TITLE
Share the cache directive tokens internally

### DIFF
--- a/packages/http-helper/src/cache/internal/token_intern.ts
+++ b/packages/http-helper/src/cache/internal/token_intern.ts
@@ -1,0 +1,23 @@
+// XXX: DO NOT EXPOSE THESE DIRECTLY.
+//
+// At least TypeScript v5.1, we need to assignment an another variable
+// to provide an another JSDoc information for variables.
+// `export { A as B }` cannot provide a different JSDoc info.
+//
+// Please assign to an another variable once before exporting as an user facing feature.
+export const TOKEN_IMMUTABLE = 'immutable' as const;
+export const TOKEN_MAX_AGE = 'max-age' as const;
+export const TOKEN_MAX_STALE = 'max-stale' as const;
+export const TOKEN_MIN_FRESH = 'min-fresh' as const;
+export const TOKEN_MUST_REVALIDATE = 'must-revalidate' as const;
+export const TOKEN_MUST_UNDERSTAND = 'must-understand' as const;
+export const TOKEN_NO_CACHE = 'no-cache' as const;
+export const TOKEN_NO_STORE = 'no-store' as const;
+export const TOKEN_NO_TRANSFORM = 'no-transform' as const;
+export const TOKEN_ONLY_IF_CACHED = 'only-if-cached' as const;
+export const TOKEN_PRIVATE = 'private' as const;
+export const TOKEN_PROXY_REVALIDATE = 'proxy-revalidate' as const;
+export const TOKEN_PUBLIC = 'public' as const;
+export const TOKEN_S_MAXAGE = 's-maxage' as const;
+export const TOKEN_STALE_IF_ERROR = 'stale-if-error' as const;
+export const TOKEN_STALE_WHILE_REVALIDATE = 'stale-while-revalidate' as const;

--- a/packages/http-helper/src/cache/request_directive.ts
+++ b/packages/http-helper/src/cache/request_directive.ts
@@ -1,44 +1,54 @@
 //  @see
 //  - https://www.rfc-editor.org/rfc/rfc9111.html#name-request-directives
 //  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#request_directives
+import {
+    TOKEN_MAX_AGE,
+    TOKEN_MAX_STALE,
+    TOKEN_MIN_FRESH,
+    TOKEN_NO_CACHE,
+    TOKEN_NO_STORE,
+    TOKEN_NO_TRANSFORM,
+    TOKEN_ONLY_IF_CACHED,
+    TOKEN_STALE_IF_ERROR,
+} from './internal/token_intern.js';
 
 /**
  *  - https://www.rfc-editor.org/rfc/rfc9111.html#name-max-age
  */
-export const MAX_AGE = 'max-age' as const;
+export const MAX_AGE = TOKEN_MAX_AGE;
 
 /**
  *  - https://www.rfc-editor.org/rfc/rfc9111.html#name-max-stale
  */
-export const MAX_STALE = 'max-stale' as const;
+export const MAX_STALE = TOKEN_MAX_STALE;
 
 /**
  *  - https://www.rfc-editor.org/rfc/rfc9111.html#name-min-fresh
  */
-export const MIN_FRESH = 'min-fresh' as const;
+export const MIN_FRESH = TOKEN_MIN_FRESH;
 
 /**
  *  - https://www.rfc-editor.org/rfc/rfc9111.html#name-no-cache
  */
-export const NO_CACHE = 'no-cache' as const;
+export const NO_CACHE = TOKEN_NO_CACHE;
 
 /**
  *  - https://www.rfc-editor.org/rfc/rfc9111.html#name-no-store
  */
-export const NO_STORE = 'no-store' as const;
+export const NO_STORE = TOKEN_NO_STORE;
 
 /**
  *  - https://www.rfc-editor.org/rfc/rfc9111.html#name-no-transform
  */
-export const NO_TRANSFORM = 'no-transform' as const;
+export const NO_TRANSFORM = TOKEN_NO_TRANSFORM;
 
 /**
  *  - https://www.rfc-editor.org/rfc/rfc9111.html#name-only-if-cached
  */
-export const ONLY_IF_CACHED = 'only-if-cached' as const;
+export const ONLY_IF_CACHED = TOKEN_ONLY_IF_CACHED;
 
 /**
  *  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error
  *  - https://datatracker.ietf.org/doc/rfc5861/
  */
-export const STALE_IF_ERROR = 'stale-if-error' as const;
+export const STALE_IF_ERROR = TOKEN_STALE_IF_ERROR;

--- a/packages/http-helper/src/cache/response_directive.ts
+++ b/packages/http-helper/src/cache/response_directive.ts
@@ -1,71 +1,86 @@
 //  @see
 //  - https://www.rfc-editor.org/rfc/rfc9111.html#name-response-directives
 //  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#response_directives
+import {
+    TOKEN_IMMUTABLE,
+    TOKEN_MAX_AGE,
+    TOKEN_MUST_REVALIDATE,
+    TOKEN_MUST_UNDERSTAND,
+    TOKEN_NO_CACHE,
+    TOKEN_NO_STORE,
+    TOKEN_NO_TRANSFORM,
+    TOKEN_PRIVATE,
+    TOKEN_PROXY_REVALIDATE,
+    TOKEN_PUBLIC,
+    TOKEN_STALE_IF_ERROR,
+    TOKEN_STALE_WHILE_REVALIDATE,
+    TOKEN_S_MAXAGE,
+} from './internal/token_intern.js';
 
 /**
  *  - https://datatracker.ietf.org/doc/rfc8246/
  *  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#immutable
  */
-export const IMMUTABLE = 'immutable' as const;
+export const IMMUTABLE = TOKEN_IMMUTABLE;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-max-age-2
  */
-export const MAX_AGE = 'max-age' as const;
+export const MAX_AGE = TOKEN_MAX_AGE;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-must-revalidate
  */
-export const MUST_REVALIDATE = 'must-revalidate' as const;
+export const MUST_REVALIDATE = TOKEN_MUST_REVALIDATE;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-must-understand
  */
-export const MUST_UNDERSTAND = 'must-understand' as const;
+export const MUST_UNDERSTAND = TOKEN_MUST_UNDERSTAND;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-no-cache-2
  */
-export const NO_CACHE = 'no-cache' as const;
+export const NO_CACHE = TOKEN_NO_CACHE;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-no-store-2
  */
-export const NO_STORE = 'no-store' as const;
+export const NO_STORE = TOKEN_NO_STORE;
 
 /**
  * https://www.rfc-editor.org/rfc/rfc9111.html#name-no-transform-2
  */
-export const NO_TRANSFORM = 'no-transform' as const;
+export const NO_TRANSFORM = TOKEN_NO_TRANSFORM;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-private
  */
-export const PRIVATE = 'private' as const;
+export const PRIVATE = TOKEN_PRIVATE;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-proxy-revalidate
  */
-export const PROXY_REVALIDATE = 'proxy-revalidate' as const;
+export const PROXY_REVALIDATE = TOKEN_PROXY_REVALIDATE;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-public
  */
-export const PUBLIC = 'public' as const;
+export const PUBLIC = TOKEN_PUBLIC;
 
 /**
  *  https://www.rfc-editor.org/rfc/rfc9111.html#name-s-maxage
  */
-export const S_MAXAGE = 's-maxage' as const;
+export const S_MAXAGE = TOKEN_S_MAXAGE;
 
 /**
  *  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error
  *  - https://datatracker.ietf.org/doc/rfc5861/
  */
-export const STALE_IF_ERROR = 'stale-if-error' as const;
+export const STALE_IF_ERROR = TOKEN_STALE_IF_ERROR;
 
 /**
  *  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate
  *  - https://datatracker.ietf.org/doc/rfc5861/
  */
-export const STALE_WHILE_REVALIDATE = 'stale-while-revalidate' as const;
+export const STALE_WHILE_REVALIDATE = TOKEN_STALE_WHILE_REVALIDATE;


### PR DESCRIPTION
cache directives use same token that are sharable. 

This change can be safe by [our tests that checks what is exported](https://github.com/Nikkei/node-http-helper/tree/main/packages/unittests/__tests__/cache)

## Design Details.

Ideally, we would like to use `export { A as B } from '...';` pattern to reduce an intermediate variable. But it cannot provide a different JSDoc info by re-export paths.

To provide an another JSDoc information for variables, at least TypeScript v5.1, we need to assignment an another variable.