### PR TITLE
Sort the value of tsconfig's `module` with `moduleResolution` to avoid TS5.2's breaking change

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,7 +25,7 @@
         "moduleDetection": "force" /* Control what method is used to detect module-format JS files. */,
 
         /* Modules */
-        "module": "es2022" /* Specify what module code is generated. */,
+        "module": "Node16" /* Specify what module code is generated. */,
         // "rootDir": "./",                                  /* Specify the root folder within your source files. */
         "moduleResolution": "node16" /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
To make a future upgrade smooth, we should sort their values.

see: https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/