### PR TITLE
Add `HttpMethodType` type that represents all available http methods

### DIFF
--- a/packages/http-helper/src/mod.ts
+++ b/packages/http-helper/src/mod.ts
@@ -1,9 +1,12 @@
+import * as HttpMethod from './http_method.js';
+
 export * as Auth from './auth/mod.js';
 export * as Cache from './cache/mod.js';
 export * as ClearSiteData from './clear_site_data.js';
 export * as CSP from './csp/mod.js';
 export * as HttpHeaderName from './http_header_name.js';
-export * as HttpMethod from './http_method.js';
+export { HttpMethod };
+export type HttpMethodType = keyof typeof HttpMethod;
 export * as HttpStatus from './http_status_code.js';
 export * as Mime from './mime.js';
 export { SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser } from './sec_fetch/mod.js';


### PR DESCRIPTION
This PR newly introduces a utility type to indicates available http methods.

### Usecase
In some http frameworks or http routers, they define function that receives http methods name as argument like
```ts
async function registerRoute(method: HttpMethodType, path: string, handler: Function){
}
```

### other libraries implementation 
Fastify: https://github.com/fastify/fastify/blob/128b6d4ffa8fb064abd0c9a498bed9ff35fc694c/types/utils.d.ts#L11C16-L11C16