### PR TITLE
dependabot should watch in-repository composite actions under /.github/actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     - package-ecosystem: github-actions
       directory: '/'
       schedule:
-          interval: weekly
+          interval: monthly
       open-pull-requests-limit: 99
       labels:
           - 'A-dependency/gardening'
@@ -14,7 +14,7 @@ updates:
     - package-ecosystem: npm
       directory: '/'
       schedule:
-          interval: weekly
+          interval: monthly
       open-pull-requests-limit: 99
       labels:
           - 'A-dependency/gardening'
@@ -44,7 +44,7 @@ updates:
     - package-ecosystem: github-actions
       directory: '/.github/actions/prepare_ci'
       schedule:
-          interval: weekly
+          interval: monthly
       open-pull-requests-limit: 99
       labels:
           - 'A-dependency/gardening'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,15 @@ updates:
           typescript-eslint:
               patterns:
                   - '@typescript-eslint/*'
+
+    #####################################################
+    #   In-repository composite actions
+    #####################################################
+    - package-ecosystem: github-actions
+      directory: '/.github/actions/prepare_ci'
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 99
+      labels:
+          - 'A-dependency/gardening'
+          - I-enhancement


### PR DESCRIPTION
This makes dependabot watching under in-repo composite actions under `/.github/actions`.

Additionaly, this PR changes dependabot interval.