### PR TITLE
Remove the comment about csp's obsoleted `navigate-to`

### DIFF
--- a/packages/http-helper/src/csp/directives/navigation.ts
+++ b/packages/http-helper/src/csp/directives/navigation.ts
@@ -16,7 +16,3 @@ export type FormActionDirective = SerializedDirective<typeof DIRECTIVE_FORM_ACTI
  */
 export const DIRECTIVE_FRAME_ANCESTORS = 'frame-ancestors';
 export type FrameAncestorsDirective = SerializedDirective<typeof DIRECTIVE_FRAME_ANCESTORS>;
-
-// https://w3c.github.io/webappsec-csp/#directive-navigate-to
-// We think there is no implementation of this directive by MDN
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to


### PR DESCRIPTION
That has been [removed from the spec](https://github.com/w3c/webappsec-csp/commit/5f6b45ac07858949aa432d69a8f618ee42f8e22f)