### PR TITLE
Update option-t to v48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,9 +2198,9 @@
             }
         },
         "node_modules/option-t": {
-            "version": "45.1.0",
-            "resolved": "https://registry.npmjs.org/option-t/-/option-t-45.1.0.tgz",
-            "integrity": "sha512-l3OK8mHTKsTtR90p5vcQNyeI7IOd/Lw+MBhxsytcz/etKgOuV9NUpcSrRGmbHEgXd8kCx5IrXqkGYTElqYXGsw==",
+            "version": "48.0.1",
+            "resolved": "https://registry.npmjs.org/option-t/-/option-t-48.0.1.tgz",
+            "integrity": "sha512-xN+N/XvwcZ80JUyWg5ve0KH+ILj4HLSpnA+SttX4VQWf1O23e4Hq2dwRp22dMsMU2c5UMnyEgsWbamL38aM7Zg==",
             "engines": {
                 "node": ">=16.20.0"
             }
@@ -2981,7 +2981,7 @@
             "version": "2.4.3",
             "license": "MIT",
             "dependencies": {
-                "option-t": "^45.1.0"
+                "option-t": "^48.0.1"
             }
         },
         "packages/unittests": {
@@ -2989,7 +2989,7 @@
             "version": "0.0.0",
             "dependencies": {
                 "@nikkei/http-helper": "*",
-                "option-t": "^45.1.0",
+                "option-t": "^48.0.1",
                 "vitest": "^1.6.0"
             }
         }

--- a/packages/http-helper/package.json
+++ b/packages/http-helper/package.json
@@ -49,6 +49,6 @@
     },
     "homepage": "https://github.com/Nikkei/node-http-helper",
     "dependencies": {
-        "option-t": "^45.1.0"
+        "option-t": "^48.0.1"
     }
 }

--- a/packages/http-helper/src/csp/directives/serialize.ts
+++ b/packages/http-helper/src/csp/directives/serialize.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from 'option-t/Nullable/Nullable';
+import type { Nullable } from 'option-t/nullable/nullable';
 import { serializeSourceList } from '../source_list.js';
 
 /**

--- a/packages/http-helper/src/csp/policy.ts
+++ b/packages/http-helper/src/csp/policy.ts
@@ -1,4 +1,4 @@
-import { isNotNull, type Nullable } from 'option-t/Nullable/Nullable';
+import { isNotNull, type Nullable } from 'option-t/nullable/nullable';
 
 // https://w3c.github.io/webappsec-csp/#grammardef-serialized-policy
 export function serializePolicy(...values: Array<Nullable<string>>) {

--- a/packages/http-helper/src/csp/source_list.ts
+++ b/packages/http-helper/src/csp/source_list.ts
@@ -1,4 +1,4 @@
-import { type Nullable, isNotNull } from 'option-t/Nullable/Nullable';
+import { type Nullable, isNotNull } from 'option-t/nullable/nullable';
 
 /**
  *  https://w3c.github.io/webappsec-csp/#grammardef-serialized-source-list

--- a/packages/unittests/__tests__/csp/serialize_directive.test.ts
+++ b/packages/unittests/__tests__/csp/serialize_directive.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'vitest';
-import type { Nullable } from 'option-t/Nullable/Nullable';
+import type { Nullable } from 'option-t/nullable/nullable';
 import { serializeDirective } from '@nikkei/http-helper/csp';
 
 describe('serializeDirective: should throw if string to 2nd argument directly', () => {

--- a/packages/unittests/__tests__/csp/serialize_source_list.test.ts
+++ b/packages/unittests/__tests__/csp/serialize_source_list.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import type { Nullable } from 'option-t/Nullable/Nullable';
+import type { Nullable } from 'option-t/nullable/nullable';
 import { serializeSourceList } from '@nikkei/http-helper/csp';
 
 {

--- a/packages/unittests/package.json
+++ b/packages/unittests/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@nikkei/http-helper": "*",
-        "option-t": "^45.1.0",
+        "option-t": "^48.0.1",
         "vitest": "^1.6.0"
     }
 }


### PR DESCRIPTION
I do this migration by codemod noted in https://github.com/option-t/option-t/releases/tag/v45.2.0

## Release Notes

- https://github.com/option-t/option-t/releases/tag/v45.2.0
- https://github.com/option-t/option-t/releases/tag/v45.3.0
- https://github.com/option-t/option-t/releases/tag/v46.0.0
- https://github.com/option-t/option-t/releases/tag/v46.1.0
- https://github.com/option-t/option-t/releases/tag/v46.2.0
- https://github.com/option-t/option-t/releases/tag/v46.3.0
- https://github.com/option-t/option-t/releases/tag/v47.0.0
- https://github.com/option-t/option-t/releases/tag/v48.0.1