### PR TITLE
Use Node.js v22 for CI

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -6,7 +6,7 @@ runs:
     steps:
         - uses: actions/setup-node@v4
           with:
-              node-version: 18
+              node-version: 22
               cache: 'npm'
 
         # - https://nodejs.org/docs/latest-v19.x/api/corepack.html


### PR DESCRIPTION
To land https://github.com/Nikkei/node-http-helper/pull/306 without introducing `Set` helper shims, we bump up Node.js used in CI to v22.

This does not introduce any breaking changes for us.