### PR TITLE
Update TypeScript to 5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "eslint": "^9.15.0",
                 "eslint-config-prettier": "^9.0.0",
                 "globals": "^15.12.0",
-                "prettier": "^3.3.3",
+                "prettier": "^3.4.0",
                 "typescript": "^5.5.4"
             }
         },
@@ -2170,10 +2170,11 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.0.tgz",
+            "integrity": "sha512-/OXNZcLyWkfo13ofOW5M7SLh+k5pnIs07owXK2teFpnfaOEcycnSy7HQxldaVX1ZP/7Q8oO1eDuQJNwbomQq5Q==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "eslint-config-prettier": "^9.0.0",
                 "globals": "^15.12.0",
                 "prettier": "^3.4.0",
-                "typescript": "^5.5.4"
+                "typescript": "^5.7.2"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2446,10 +2446,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "eslint": "^9.15.0",
         "eslint-config-prettier": "^9.0.0",
         "globals": "^15.12.0",
-        "prettier": "^3.3.3",
+        "prettier": "^3.4.0",
         "typescript": "^5.5.4"
     },
     "packageManager": "npm@9.6.3"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "eslint-config-prettier": "^9.0.0",
         "globals": "^15.12.0",
         "prettier": "^3.4.0",
-        "typescript": "^5.5.4"
+        "typescript": "^5.7.2"
     },
     "packageManager": "npm@9.6.3"
 }

--- a/packages/http-helper/README.md
+++ b/packages/http-helper/README.md
@@ -4,18 +4,18 @@ This package provides constants and utility for well-known http values defined i
 
 ## Design Goals
 
--   **ES Module support as Tier 1**
-    -   This allows us tree shaking friendly.
--   **TypeScript friendly APIs**
--   **Easy to replacement**.
-    -   This does not aim to framework lock-in.
-    -   This allows to replace your codebase incrementally.
--   **Well documented for related specs**
+- **ES Module support as Tier 1**
+    - This allows us tree shaking friendly.
+- **TypeScript friendly APIs**
+- **Easy to replacement**.
+    - This does not aim to framework lock-in.
+    - This allows to replace your codebase incrementally.
+- **Well documented for related specs**
 
 ## Not Goals
 
 We'd like to keep this as a _helper_ which you can replace easily.
 So we don't aim following goals.
 
--   **Comprehensive wrapper for some specific framework.**
--   **Hard to migrate from/to this package.**
+- **Comprehensive wrapper for some specific framework.**
+- **Hard to migrate from/to this package.**

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -102,6 +102,8 @@
         // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
         // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
+        "noUncheckedSideEffectImports": true,
+
         /* Completeness */
         // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
         "skipLibCheck": true /* Skip type checking all .d.ts files. */


### PR DESCRIPTION
_⚠️: This pull request is for the public repository_

----

This change would not break the typecheck on user's CI since this release does not contain a change
which uses TypeScript's newer feature.

Probably user doesn't have to update your TypeScript to 5.7 or later _immediately_ before import this change.

However, we may begin to use all new features in TS 5.7.
**We recommend strongly to update TypeScript for user project.** We would not provide a support with TS5.6 or earlier.

- https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/
- https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/