### PR TITLE
Remove obsoleted `eslint.experimental.useFlatConfig` config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    // With dbaeumer.vscode-eslint v2.4.0, we need to enable this option explicitly.
-    "eslint.experimental.useFlatConfig": true
-}


### PR DESCRIPTION
This option was removed at lease dbaeumer.vscode-eslint v3.0.10 now