### PR TITLE
Lock Github Actions' versions more precisely as hardening

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -4,7 +4,7 @@ description: This action prepare CI that restore cachable items
 runs:
     using: composite
     steps:
-        - uses: actions/setup-node@v4
+        - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
           with:
               node-version: 22
               cache: 'npm'

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -15,7 +15,7 @@ jobs:
     warmup_dependencies_cache:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare_ci
 
     build:
@@ -23,7 +23,7 @@ jobs:
             - warmup_dependencies_cache
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare_ci
             - run: npm run build
 
@@ -32,7 +32,7 @@ jobs:
             - warmup_dependencies_cache
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare_ci
             - run: npm run test
 
@@ -41,7 +41,7 @@ jobs:
             - warmup_dependencies_cache
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare_ci
             - run: npm run lint
 
@@ -50,7 +50,7 @@ jobs:
             - warmup_dependencies_cache
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare_ci
             - run: npm run format:check
 

--- a/.github/workflows/publish_package_to_npm.yaml
+++ b/.github/workflows/publish_package_to_npm.yaml
@@ -21,7 +21,7 @@ jobs:
             id-token: write
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare_ci
             - run: npm run build
               shell: bash


### PR DESCRIPTION
This is done by https://github.com/suzuki-shunsuke/pinact with the following pinact.yaml

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
# pinact - https://github.com/suzuki-shunsuke/pinact
files:
  - pattern: "^\\.github/actions/.+/.*\\.ya?ml$"
  - pattern: "^\\.github/workflows/.*\\.ya?ml$"
  - pattern: "^(.*/)?action\\.ya?ml$"

ignore_actions:
# - name: actions/checkout
# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
````