### PR TITLE
Add `/CODEOWNERS` file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# dependencies
+/package.json @arayaryoma @negibokken @taitotnk @zoesrr
+**/package.json @arayaryoma @negibokken @taitotnk @zoesrr
+/package-lock.json @arayaryoma @negibokken @taitotnk @zoesrr


### PR DESCRIPTION
By the organization governance policy, we cannot create a new reviewer team quickly for an open sourced project. We have to add reviewer individually.